### PR TITLE
Hide/show bg image and dashboard

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -18,6 +18,7 @@ const signInSuccess = (data) => {
   console.log('sign in ran and data is ', data)
   $('#signin-modal').modal('hide')
   $('#signin-error').hide()
+  $('#landing-page-content').hide()
 }
 
 const signInFailure = (error) => {
@@ -40,6 +41,8 @@ const signOutSuccess = (data) => {
   store.user = null
   console.log('sign in ran and data is ', data)
   $('#signout-modal').modal('hide')
+  $('#landing-page-content').show()
+  $('#dashboard').hide()
 }
 
 const signOutFailure = (error) => {

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -7,6 +7,34 @@ $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/';
 //     // background-position: right 1;
 // }
 
+// begin Joni changePassword
+html, body {
+    padding: 0;
+    margin: 0;
+}
+
+#dashboard {
+  background-image:none !important;
+  display: none;
+}
+
+#landing-page-content {
+  background-image: url("../../assets/images/jump.jpg");
+  margin: 0;
+  border: none;
+  width: 100%;
+  height: 100%;
+  box-sizing:border-box;
+  -moz-box-sizing:border-box;
+  -webkit-box-sizing:border-box;
+}
+
+.navbar {
+    margin-bottom: 0;
+}
+
+// end Joni changes
+
 img{
     position:fixed;
     right:0;
@@ -52,27 +80,27 @@ img{
   background-color: orange;
 }
 
-@media (max-width: 300px) {
-  body {
-    background-color: #000;
-    background-image: url("../../assets/images/jumpsmall.jpg");
-  }
-}
-@media (min-width: 301px) and (max-width: 600px) {
-  body {
-    background-color: #000;
-    background-image: url("../../assets/images/jump.jpg");
-  }
-}
-@media (min-width: 601px) and (max-width: 768px) {
-  body {
-    background-color: #000;
-    background-image: url("../../assets/images/jump.jpg");
-  }
-}
-@media (min-width: 769px) {
-  body {
-    background-color: #000;
-    background-image: url("../../assets/images/jump.jpg");
-  }
-}
+// @media (max-width: 300px) {
+//   body {
+//     background-color: #000;
+//     background-image: url("../../assets/images/jumpsmall.jpg");
+//   }
+// }
+// @media (min-width: 301px) and (max-width: 600px) {
+//   body {
+//     background-color: #000;
+//     background-image: url("../../assets/images/jump.jpg");
+//   }
+// }
+// @media (min-width: 601px) and (max-width: 768px) {
+//   body {
+//     background-color: #000;
+//     background-image: url("../../assets/images/jump.jpg");
+//   }
+// }
+// @media (min-width: 769px) {
+//   body {
+//     background-color: #000;
+//     background-image: url("../../assets/images/jump.jpg");
+//   }
+// }

--- a/index.html
+++ b/index.html
@@ -228,6 +228,9 @@
   <!--end signout modal-->
 
 
+
+
+<div id="landing-page-content">
   <div id="welcome">
     <p>Welcome to</p>
   </div>
@@ -242,6 +245,12 @@
   <div id="getstarted-button">
     <a href="#signin-modal" data-toggle="modal" data-target="#signin-modal"><button type="button" class="btn btn-success btn-lg">Get Started</button></a>
   </div>
+  <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+</div> <!--end landing page content div-->
+
+
+
+
 
   <!-- Modal for Page Template 1 -->
   <div class="modal fade in" id="page-template-1-modal" tabindex="-1" role="dialog" style="display:none">


### PR DESCRIPTION
Added code/css to hide and show the background image with text
and dashboard based on whether or not a user is authenticated.
Upon signin, background image with welcome text disappears and
dashboard appears.  Upon signout, dashboard disappears and background
image appears.
Commented out the @media queries because they are not functioning.  We
can revisit and remove code or rework if able to do so.
All landing page info, including b/g image, is now included in the
"landing-page-content" div so it's easy to show/hide.  All dashboard
content will live in the "dashboard" div.